### PR TITLE
Bundle.identifier und Bundle.fullUrl sind seitens Core-Spec verpflichend, Search, Request, Response -> keine Verwendung in Document bundle

### DIFF
--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKBerichtBundle.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKBerichtBundle.json
@@ -64,6 +64,12 @@
         ]
       },
       {
+        "id": "Bundle.identifier",
+        "path": "Bundle.identifier",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
         "id": "Bundle.type",
         "path": "Bundle.type",
         "fixedCode": "document",
@@ -89,6 +95,33 @@
         },
         "min": 1,
         "mustSupport": true
+      },
+      {
+        "id": "Bundle.entry.fullUrl",
+        "path": "Bundle.entry.fullUrl",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Bundle.entry.resource",
+        "path": "Bundle.entry.resource",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Bundle.entry.search",
+        "path": "Bundle.entry.search",
+        "max": "0"
+      },
+      {
+        "id": "Bundle.entry.request",
+        "path": "Bundle.entry.request",
+        "max": "0"
+      },
+      {
+        "id": "Bundle.entry.response",
+        "path": "Bundle.entry.response",
+        "max": "0"
       },
       {
         "id": "Bundle.entry:Composition",

--- a/Resources/input/fsh/ISiKBerichtBundle.fsh
+++ b/Resources/input/fsh/ISiKBerichtBundle.fsh
@@ -8,7 +8,13 @@ Description: "A document style representation of the receipt (complete, self-con
 * type = #document (exactly)
 * type MS
 * timestamp 1.. MS
+* identifier 1.. MS
 * entry MS
+  * fullUrl 1..1 MS
+  * resource 1..1 MS
+  * search 0..0
+  * request 0..0
+  * response 0..0
   * ^slicing.discriminator.type = #value
   * ^slicing.discriminator.path = "resource.type.coding.code"
   * ^slicing.rules = #open


### PR DESCRIPTION
Fixes #61 